### PR TITLE
Give a new badge to the user every game - quick fix for Demo Day

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -11,7 +11,13 @@ class GamesController < ApplicationController
     @flight_count = params[:flight_count]
     badges_before = session[:badges_before]
     badges_all = current_user.badges.map(&:id) || []
-    @new_badge_ids = badges_all - badges_before
+    # FOR DEMO DAY
+    # If there are no new badges (which is likely to happen if we play a second game)
+    # Assign badge 'Frequent FLyer'
+    @new_badge_ids = (badges_all - badges_before)
+    if !@new_badge_ids || @new_badge_ids.empty?
+      @new_badge_ids = [ 4 ]
+    end
     @new_badges = @new_badge_ids.map { |id| Merit::Badge.find(id) }
 
     # FOR TESTING DISPLAYING BADGES ONLY

--- a/config/initializers/merit.rb
+++ b/config/initializers/merit.rb
@@ -101,12 +101,4 @@ Rails.application.reloader.to_prepare do
     description: "Awarded for spotting 10 airlines.",
     custom_fields: { difficulty: :platinum, icon: "badges/airline_spotter.png", color: "text-primary" }
   )
-
-  # FOR DEBUGGING
-  Merit::Badge.create!(
-    id: 999,
-    name: "Second Game",
-    description: "Second game played",
-    custom_fields: { difficulty: :bronze, icon: "badges/first_game.png", color: "text-warning" }
-  )
 end

--- a/config/initializers/merit.rb
+++ b/config/initializers/merit.rb
@@ -101,4 +101,12 @@ Rails.application.reloader.to_prepare do
     description: "Awarded for spotting 10 airlines.",
     custom_fields: { difficulty: :platinum, icon: "badges/airline_spotter.png", color: "text-primary" }
   )
+
+  # FOR DEBUGGING
+  Merit::Badge.create!(
+    id: 999,
+    name: "Second Game",
+    description: "Second game played",
+    custom_fields: { difficulty: :bronze, icon: "badges/first_game.png", color: "text-warning" }
+  )
 end


### PR DESCRIPTION
The results page uses position:absolute for many elements: green checkmarks, corrected answers in red.
If there are no new badges, the page looks terrible.
For Demo Day, quick fix: even if the user didn't get any new badge, add a new badge anyway.
This is important if we have time to do another game during the demo, as there usually aren't any new badges given on the second game.

*** In the second commit, I removed a new badge that I had added on Merit. Instead, the games controller will just add the badge 'Frequent Flyer' to the user if the user didn't get any new badges duriing the game.