### PR TITLE
Fixed layout bug in results page if there are no badges

### DIFF
--- a/app/assets/stylesheets/components/_ticket.scss
+++ b/app/assets/stylesheets/components/_ticket.scss
@@ -105,7 +105,7 @@
 
     .airline-checkmark {
       position: absolute;
-      bottom: 300px;
+      top: 360px;
       right: 100px;
     }
 
@@ -134,7 +134,7 @@
 
     .airline-correct-answer {
       position: absolute;
-      bottom: 290px;
+      top: 362px;
       left: 100px;
       font-size: 48px;
     }

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -11,13 +11,16 @@ class GamesController < ApplicationController
     @flight_count = params[:flight_count]
     badges_before = session[:badges_before]
     badges_all = current_user.badges.map(&:id) || []
-    # FOR DEMO DAY
+    @new_badge_ids = (badges_all - badges_before)
+
+
+    # QUICK FIX FOR DEMO DAY
     # If there are no new badges (which is likely to happen if we play a second game)
     # Assign badge 'Frequent FLyer'
-    @new_badge_ids = (badges_all - badges_before)
-    if !@new_badge_ids || @new_badge_ids.empty?
-      @new_badge_ids = [ 4 ]
-    end
+    # if !@new_badge_ids || @new_badge_ids.empty?
+    #   @new_badge_ids = [ 4 ]
+    # end
+
     @new_badges = @new_badge_ids.map { |id| Merit::Badge.find(id) }
 
     # FOR TESTING DISPLAYING BADGES ONLY


### PR DESCRIPTION
In the previous version, the green checkmark / correct answer for the airline would be wrongly positioned if the page didn't display new badges.
Fixed it using position: absolute top: instead of bottom:
![Position: absolute bottom](https://github.com/user-attachments/assets/df6f1396-7e8f-40af-ab46-7dd856af7095)
